### PR TITLE
added 'tasks' command

### DIFF
--- a/src/Altax/Command/Builtin/TasksCommand.php
+++ b/src/Altax/Command/Builtin/TasksCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Altax\Command\Builtin;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\DescriptorHelper;
+use Altax\Module\Env\Facade\Env;
+
+/**
+ * Tasks Command
+ *
+ * @author Damien Pitard <damien.pitard@gmail.com>
+ */
+class TasksCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('tasks')
+            ->setDefinition(new InputDefinition(array(
+                new InputOption('format', null, InputOption::VALUE_REQUIRED, 'To output list in other formats', 'txt')
+            )))
+            ->setDescription('Lists defined tasks')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $container = $this->getApplication()->getContainer();
+        $tasks = $container->get('tasks');
+
+        $format = $input->getOption('format');
+        if ('txt' === $format) {
+            if ($tasks) {
+                $table = $this->getHelperSet()->get('table');
+                $table->setHeaders(array('name', 'description', 'hidden'));
+                foreach ($tasks as $task) {
+                    $table->addRow(array(
+                        $task->getName(),
+                        $task->getDescription(),
+                        $task->isHidden()?'X':'',
+                    ));
+                }
+
+                $table->render($output);
+            } else {
+                $output->writeln('No tasks defined.');
+            }
+        } else if ('json' === $format) {
+            $data = array();
+            if ($tasks) {
+                foreach ($tasks as $task) {
+                    $data[] = array(
+                        'name' => $task->getName(),
+                        'description' => $task->getDescription(),
+                        'hidden' => $task->isHidden()
+                    );
+                }
+            }
+            $output->writeln(json_encode($data));
+        } else {
+            throw new \InvalidArgumentException(sprintf('Unsupported format "%s".', $options['format']));
+        }
+    }
+}


### PR DESCRIPTION
Hi Kohki,

This PR add the command "tasks" to list all defined tasks in config (it does not list built-in commands):

``` bash
altax tasks
```

You can also have the output formated in json this way:

``` bash
altax tasks --format=json
```

It is usefull to integrate altax in another runner based on command line (my usecase).

I plan also to add support for `--format=json` to https://github.com/kohkimakimoto/altax/blob/master/src/Altax/Command/Builtin/NodesCommand.php

thanks,
Damien
