### PR TITLE
[WIP] Support windows 

### DIFF
--- a/src/Altax/Module/Task/Process/Executor.php
+++ b/src/Altax/Module/Task/Process/Executor.php
@@ -241,8 +241,7 @@ class Executor
     {
         foreach ($this->childPids as $pid => $host) {
             $this->runtimeTask->getOutput()->writeln("<fg=red>Sending sigint to child (pid:</fg=red><comment>$pid</comment><fg=red>)</fg=red>");
-            // TODO:support windows 
-            posix_kill($pid, SIGINT);
+            $this->killProcess($pid);
         }
     }
 
@@ -254,6 +253,22 @@ class Executor
     public function getIsParallel()
     {
         return $this->isParallel;
+    }
+
+    protected function killProcess($pid)
+    {
+        if (!function_exists('posix_kill')) {
+            // For windows.
+            // See http://www.php.net/manual/ja/function.posix-kill.php
+            // I haven't tested the code. Sorry.
+            $wmi = new COM("winmgmts:{impersonationLevel=impersonate}!\\\\.\\root\\cimv2"); 
+            $procs = $wmi->ExecQuery("SELECT * FROM Win32_Process WHERE ProcessId='".$pid."'"); 
+            foreach($procs as $proc) {
+                $proc->Terminate();
+            }
+        } else {
+            posix_kill($pid, SIGINT);
+        }
     }
 
     /**

--- a/src/Altax/Module/Task/Process/Process.php
+++ b/src/Altax/Module/Task/Process/Process.php
@@ -278,14 +278,23 @@ class Process
     }
     public function getRemoteInfoPrefix()
     {
-        // TODO:support windows 
-        return "<info>[</info><comment>".$this->getNodeName().":".posix_getpid()."</comment><info>]</info> ";
+        return "<info>[</info><comment>".$this->getNodeName().":".$this->getPid()."</comment><info>]</info> ";
     }
 
     public function getLocalInfoPrefix()
     {
-        // TODO:support windows 
-        return "<info>[</info><comment>localhost:".posix_getpid()."</comment><info>]</info> ";
+        return "<info>[</info><comment>localhost:".$this->getPid()."</comment><info>]</info> ";
+    }
+
+    protected function getPid()
+    {
+        $pid = null;
+        if (!function_exists('posix_getpid')) {
+            $pid = getmypid();
+        } else {
+            $pid = posix_getpid();
+        }
+        return $pid;
     }
 
     public function getRuntimeTask()


### PR DESCRIPTION
See #33 
- Don't use `posix_***` functions when it runs on Windows platform. 
