### PR TITLE
windowsへの対応について

### DIFF
--- a/src/Altax/Command/Builtin/InitCommand.php
+++ b/src/Altax/Command/Builtin/InitCommand.php
@@ -77,7 +77,7 @@ EOL;
         $configurationPath = getcwd()."/.altax/config.php";
 
         if($input->getOption('global')) {
-            $configurationPath = getenv("HOME")."/.altax/config.php";
+            $configurationPath = Env::get("homedir")."/.altax/config.php";
         }
 
         if (!is_file($configurationPath)) {

--- a/src/Altax/Command/Builtin/InstallCommand.php
+++ b/src/Altax/Command/Builtin/InstallCommand.php
@@ -63,7 +63,7 @@ class InstallCommand extends \Composer\Command\InstallCommand
     private function getNewWorkingDir(InputInterface $input)
     {
         if($input->getOption('global')) {
-            return  getenv("HOME")."/.altax";
+            return  Env::get("homedir")."/.altax";
         }
 
         $workingDir = $input->getParameterOption(array('--working-dir', '-d'));

--- a/src/Altax/Command/Builtin/RequireCommand.php
+++ b/src/Altax/Command/Builtin/RequireCommand.php
@@ -62,7 +62,7 @@ class RequireCommand extends \Composer\Command\RequireCommand
     private function getNewWorkingDir(InputInterface $input)
     {
         if($input->getOption('global')) {
-            return  getenv("HOME")."/.altax";
+            return  Env::get("homedir")."/.altax";
         }
 
         $workingDir = $input->getParameterOption(array('--working-dir', '-d'));

--- a/src/Altax/Command/Builtin/UpdateCommand.php
+++ b/src/Altax/Command/Builtin/UpdateCommand.php
@@ -63,7 +63,7 @@ class UpdateCommand extends \Composer\Command\UpdateCommand
     private function getNewWorkingDir(InputInterface $input)
     {
         if($input->getOption('global')) {
-            return  getenv("HOME")."/.altax";
+            return  Env::get("homedir")."/.altax";
         }
 
         $workingDir = $input->getParameterOption(array('--working-dir', '-d'));

--- a/src/Altax/Foundation/boot.php
+++ b/src/Altax/Foundation/boot.php
@@ -7,9 +7,11 @@
  */
 $container = new \Altax\Foundation\Container();
 
+$homedir = getenv("HOME") ? getenv("HOME") : getenv("USERPROFILE");
+
 // Determine Loaded configuration files.
 $container->setConfigFiles(array(
-    "home" => getenv("HOME")."/.altax/config.php",
+    "home" => $homedir."/.altax/config.php",
     "current", getcwd()."/.altax/config.php",
     ));
 

--- a/src/Altax/Module/Env/EnvModule.php
+++ b/src/Altax/Module/Env/EnvModule.php
@@ -15,9 +15,12 @@ class EnvModule extends Module
     {
         parent::__construct($container);
 
+        $homedir = getenv("HOME") ? getenv("HOME") : getenv("USERPROFILE");
+        $this->set("homedir", $homedir);
+
         // Default values.
         $this->set("server.port", 22);
-        $this->set("server.key", getenv("HOME")."/.ssh/id_rsa");
+        $this->set("server.key", $this->get("homedir")."/.ssh/id_rsa");
         $this->set("server.username", getenv("USER"));
     }
 

--- a/src/Altax/Module/Env/EnvModule.php
+++ b/src/Altax/Module/Env/EnvModule.php
@@ -18,10 +18,13 @@ class EnvModule extends Module
         $homedir = getenv("HOME") ? getenv("HOME") : getenv("USERPROFILE");
         $this->set("homedir", $homedir);
 
+        $username = getenv("USER") ? getenv("USER") : getenv("USERNAME");
+        $this->set("username", $username);
+
         // Default values.
         $this->set("server.port", 22);
         $this->set("server.key", $this->get("homedir")."/.ssh/id_rsa");
-        $this->set("server.username", getenv("USER"));
+        $this->set("server.username", $this->get("username"));
     }
 
     public function set($key, $value)

--- a/src/Altax/Module/Server/Resource/Node.php
+++ b/src/Altax/Module/Server/Resource/Node.php
@@ -95,7 +95,7 @@ class Node
         if (strpos($key, "~") !== false) {
             // replace ~ to home directory
             $key = preg_replace_callback('/^~(?:\/|$)/', function ($m) {
-                return str_replace('~', getenv("HOME"), $m[0]);
+                return str_replace('~', Env::get("homedir"), $m[0]);
             }, $key);
 
         }

--- a/src/Altax/Module/Server/ServerModule.php
+++ b/src/Altax/Module/Server/ServerModule.php
@@ -5,6 +5,7 @@ use Altax\Foundation\Module;
 use Altax\Module\Server\Resource\Node;
 use Altax\Util\Arr;
 use Altax\Util\SSHConfig;
+use Altax\Module\Env\Facade\Env;
 
 /**
  * Server module 
@@ -88,7 +89,7 @@ class ServerModule extends Module
         $nodesOptions = SSHConfig::parseToNodeOptionsFromFiles(array(
             "/etc/ssh_config",
             "/etc/ssh/ssh_config",
-            getenv("HOME")."/.ssh/config",
+            Env::get("homedir")."/.ssh/config",
         ));
 
         foreach ($nodesOptions as $key => $option) {

--- a/tests/Altax/Command/Builtin/InstallCommandTest.php
+++ b/tests/Altax/Command/Builtin/InstallCommandTest.php
@@ -42,7 +42,7 @@ Installing dependencies (including require-dev)
 Nothing to install or update
 
 EOL;
-        $this->assertSame($expected, $commandTester->getDisplay());
+        $this->assertSame($expected, $commandTester->getDisplay(true));
         chdir($orgDir);
         @unlink($testTmpConfigDir."/composer.json");
    }

--- a/tests/Altax/Command/Builtin/NodesCommandTest.php
+++ b/tests/Altax/Command/Builtin/NodesCommandTest.php
@@ -39,7 +39,7 @@ class NodesCommandTest extends \PHPUnit_Framework_TestCase
                 )
             );
 
-        $this->assertEquals("There are not any nodes.\n", $commandTester->getDisplay());
+        $this->assertEquals("There are not any nodes.\n", $commandTester->getDisplay(true));
     }
 
     public function testDefault()
@@ -70,7 +70,7 @@ class NodesCommandTest extends \PHPUnit_Framework_TestCase
 +------------------+-------+
 
 EOL;
-        $this->assertEquals($expected, $commandTester->getDisplay());
+        $this->assertEquals($expected, $commandTester->getDisplay(true));
     }
 
     public function testDetailOutput()
@@ -102,6 +102,6 @@ EOL;
 +------------------+------+------+----------+-----+-------+
 
 EOL;
-        $this->assertEquals($expected, $commandTester->getDisplay());
+        $this->assertEquals($expected, $commandTester->getDisplay(true));
     }
 }

--- a/tests/Altax/Command/Builtin/RolesCommandTest.php
+++ b/tests/Altax/Command/Builtin/RolesCommandTest.php
@@ -39,7 +39,7 @@ class RolesCommandTest extends \PHPUnit_Framework_TestCase
                 )
             );
 
-        $this->assertEquals("There are not any roles.\n", $commandTester->getDisplay());
+        $this->assertEquals("There are not any roles.\n", $commandTester->getDisplay(true));
     }
 
     public function testDefault()
@@ -69,6 +69,6 @@ class RolesCommandTest extends \PHPUnit_Framework_TestCase
 +------+------------------------------------+
 
 EOL;
-        $this->assertEquals($expected, $commandTester->getDisplay());
+        $this->assertEquals($expected, $commandTester->getDisplay(true));
     }
 }

--- a/tests/Altax/Command/Builtin/UpdateCommandTest.php
+++ b/tests/Altax/Command/Builtin/UpdateCommandTest.php
@@ -42,7 +42,7 @@ Updating dependencies (including require-dev)
 Nothing to install or update
 
 EOL;
-        $this->assertSame($expected, $commandTester->getDisplay());
+        $this->assertSame($expected, $commandTester->getDisplay(true));
         chdir($orgDir);
         @unlink($testTmpConfigDir."/composer.json");
    }

--- a/tests/Altax/Console/ApplicationTest/config.php
+++ b/tests/Altax/Console/ApplicationTest/config.php
@@ -4,11 +4,11 @@ require_once __DIR__."/Test01Command.php";
 
 Server::nodesFromSSHConfigHosts();
 Server::node("127.0.0.1");
-Server::node("localhost", array("host" => "127.0.0.1", "username" => getenv("USER"), "port" => 22, "key" => getenv("HOME")."/.ssh/id_rsa"));
+Server::node("localhost", array("host" => "127.0.0.1", "username" => getenv("USER"), "port" => 22, "key" => Env::get("homedir")."/.ssh/id_rsa"));
 Server::role("test", array("127.0.0.1", "localhost"));
 
 Env::set("server.port", 22);
-Env::set("server.key", getenv("HOME")."/.ssh/id_rsa");
+Env::set("server.key", Env::get("homedir")."/.ssh/id_rsa");
 Env::set("server.username", getenv("USER"));
 
 // Basic test task

--- a/tests/Altax/Console/ApplicationTest/config.php
+++ b/tests/Altax/Console/ApplicationTest/config.php
@@ -2,14 +2,16 @@
 
 require_once __DIR__."/Test01Command.php";
 
+//Env::set("username", "vagrant");
+//Env::set("server.port", 2222);
+
 Server::nodesFromSSHConfigHosts();
 Server::node("127.0.0.1");
-Server::node("localhost", array("host" => "127.0.0.1", "username" => getenv("USER"), "port" => 22, "key" => Env::get("homedir")."/.ssh/id_rsa"));
+Server::node("localhost", array("host" => "127.0.0.1", "username" => Env::get("username"), "port" => Env::get("server.port"), "key" => Env::get("homedir")."/.ssh/id_rsa"));
 Server::role("test", array("127.0.0.1", "localhost"));
 
-Env::set("server.port", 22);
 Env::set("server.key", Env::get("homedir")."/.ssh/id_rsa");
-Env::set("server.username", getenv("USER"));
+Env::set("server.username", Env::get("username"));
 
 // Basic test task
 Task::register("testBasic", function($task){

--- a/tests/Altax/Module/Server/Resource/NodeTest.php
+++ b/tests/Altax/Module/Server/Resource/NodeTest.php
@@ -80,7 +80,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
     {
         $node = new Node();
 
-        putenv("HOME=/home/your");
+        Env::set("homedir", "/home/your");
         $node->setKey("~/path/to/private_key");
         $this->assertEquals("~/path/to/private_key", $node->getKey());
         $this->assertEquals("/home/your/path/to/private_key", $node->getKeyOrDefault());
@@ -93,7 +93,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("~", $node->getKey());
         $this->assertEquals("/home/your", $node->getKeyOrDefault());
 
-        putenv("HOME=/home/your\\0");
+        Env::set("homedir", "/home/your\\0");
         $node->setKey("~/path/to/private_key");
         $this->assertEquals("~/path/to/private_key", $node->getKey());
         $this->assertEquals("/home/your\\0/path/to/private_key", $node->getKeyOrDefault());

--- a/tests/Altax/Module/Task/Process/ExecutorTest.php
+++ b/tests/Altax/Module/Task/Process/ExecutorTest.php
@@ -40,24 +40,24 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $this->task = new DefinedTask();
         $this->task->setName("test_process_run");
         $this->input = new ArgvInput();
-        $this->output = new BufferedOutput();
-        $this->runtimeTask = new RuntimeTask(null, $this->task, $this->input, $this->output);
+        $this->bufOutput = new BufferedOutput();
+        $this->runtimeTask = new RuntimeTask(null, $this->task, $this->input, $this->bufOutput);
     }
 
     public function testExecute1()
     {
-        $this->output->setVerbosity(3);
+        $this->bufOutput->setVerbosity(3);
 
         $executor = new Executor($this->runtimeTask, function(){}, array());
         $executor->execute();
 
-        $output = $this->output->fetch();
+        $output = $this->bufOutput->fetch();
         $this->assertRegExp("/Found 0 nodes/", $output);
     }
 
     public function testExecute2()
     {
-        $this->output->setVerbosity(3);
+        $this->bufOutput->setVerbosity(3);
 
         $executor = new Executor($this->runtimeTask, 
             function($process){
@@ -68,13 +68,13 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
             array("127.0,0,1"));
         $executor->execute();
 
-        $output = $this->output->fetch();
+        $output = $this->bufOutput->fetch();
         $this->assertRegExp("/Found 1 nodes/", $output);
     }
 
     public function testExecute3()
     {
-        $this->output->setVerbosity(3);
+        $this->bufOutput->setVerbosity(3);
 
         $executor = new Executor($this->runtimeTask, 
             function($process){
@@ -85,13 +85,13 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
             array("127.0,0,1", "localhost"));
         $executor->execute();
 
-        $output = $this->output->fetch();
+        $output = $this->bufOutput->fetch();
         $this->assertRegExp("/Found 2 nodes/", $output);
     }
 
     public function testExecute4()
     {
-        $this->output->setVerbosity(3);
+        $this->bufOutput->setVerbosity(3);
 
         try {
             $executor = new Executor($this->runtimeTask, 
@@ -107,7 +107,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
     public function testExecute5()
     {
-        $this->output->setVerbosity(3);
+        $this->bufOutput->setVerbosity(3);
 
         $executor = new Executor($this->runtimeTask, 
             function($process){
@@ -118,14 +118,14 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
             array("test"));
         $executor->execute();
 
-        $output = $this->output->fetch();
+        $output = $this->bufOutput->fetch();
         $this->assertRegExp("/Found 2 nodes/", $output);
     }
 
     public function testExecute6()
     {
         // role array
-        $this->output->setVerbosity(3);
+        $this->bufOutput->setVerbosity(3);
 
         $executor = new Executor($this->runtimeTask, 
             function($process){
@@ -137,10 +137,10 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $executor->execute();
 
         // role string
-        $output = $this->output->fetch();
+        $output = $this->bufOutput->fetch();
         $this->assertRegExp("/Found 2 nodes/", $output);
 
-        $this->output->setVerbosity(3);
+        $this->bufOutput->setVerbosity(3);
 
         $executor = new Executor($this->runtimeTask, 
             function($process){
@@ -151,14 +151,14 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
             array("roles" => "test"));
         $executor->execute();
 
-        $output = $this->output->fetch();
+        $output = $this->bufOutput->fetch();
         $this->assertRegExp("/Found 2 nodes/", $output);
     }
 
     public function testExecute7()
     {
         // nodes array
-        $this->output->setVerbosity(3);
+        $this->bufOutput->setVerbosity(3);
 
         $executor = new Executor($this->runtimeTask, 
             function($process){
@@ -170,10 +170,10 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $executor->execute();
 
         // nodes string
-        $output = $this->output->fetch();
+        $output = $this->bufOutput->fetch();
         $this->assertRegExp("/Found 1 nodes/", $output);
 
-        $this->output->setVerbosity(3);
+        $this->bufOutput->setVerbosity(3);
 
         $executor = new Executor($this->runtimeTask, 
             function($process){
@@ -184,14 +184,14 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
             array("nodes" => "127.0.0.1"));
         $executor->execute();
 
-        $output = $this->output->fetch();
+        $output = $this->bufOutput->fetch();
         $this->assertRegExp("/Found 1 nodes/", $output);
     }
 
     public function testExecuteInSerial()
     {
         // nodes array
-        $this->output->setVerbosity(3);
+        $this->bufOutput->setVerbosity(3);
 
         $executedNodes = array();
 
@@ -205,7 +205,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $executor->execute();
 
         // nodes string
-        $output = $this->output->fetch();
+        $output = $this->bufOutput->fetch();
         $this->assertRegExp("/Running serial mode/", $output);
 
         $this->assertCount(2, $executedNodes);

--- a/tests/Altax/Module/Task/Process/ProcessTest.php
+++ b/tests/Altax/Module/Task/Process/ProcessTest.php
@@ -24,8 +24,8 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
         $this->task = new DefinedTask();
         $this->task->setName("test_process_run");
         $this->input = new ArgvInput();
-        $this->output = new BufferedOutput();
-        $this->runtimeTask = new RuntimeTask(null, $this->task, $this->input, $this->output);
+        $this->bufOutput = new BufferedOutput();
+        $this->runtimeTask = new RuntimeTask(null, $this->task, $this->input, $this->bufOutput);
 
         ModuleFacade::clearResolvedInstances();
         ModuleFacade::setContainer($this->container);

--- a/tests/bin/E2eTest.php
+++ b/tests/bin/E2eTest.php
@@ -17,7 +17,7 @@ class E2eTest extends \PHPUnit_Framework_TestCase
         $process->run();
         $this->assertEquals(true, $process->isSuccessful());
 
-        $this->assertEquals("This is a test001\n", $process->getOutput());
+        $this->assertEquals("This is a test001" . PHP_EOL, $process->getOutput());
     }
 
     public function testRunTaskTest002()


### PR DESCRIPTION
これまでは Vagrant のLinux環境にsshログインした状態で使用していたのですが、WindowsのホストOSで直接実行したくなったのでPRをお送りしました。
主に以下の3点を修正しています。

・Process::runLocally() のwindows対応
・Windows環境で実行された場合、SSH鍵を %USERPROFILE%/.ssh/ssh_config から取得するように変更
・PHPUnit がwindows環境で通過するように変更
