### PR TITLE
Fix #52 with call_user_func_array

### DIFF
--- a/src/Altax/Command/ClosureTaskCommand.php
+++ b/src/Altax/Command/ClosureTaskCommand.php
@@ -33,6 +33,9 @@ class ClosureTaskCommand extends \Altax\Command\Command
 
     protected function fire($task)
     {
-        return call_user_func($this->definedTask->getClosure(), $task);
+        //simulate the documented function signature
+        //TODO: version this API to allow for other parameter schemes
+        $args = [$task, $task->getInput()->getArgument('args')];
+        return call_user_func_array($this->definedTask->getClosure(), $args);
     }
 }


### PR DESCRIPTION
Handling parameters from Symfony's Input didn't seem to be handled at
all, but the documentation refers to handling $args as an array.

This change will wrap any Command Input args in an array, then wrap that
in another array with the definedTask object to get the signature

funciton ( object $task, array $args) { }